### PR TITLE
Prepare release v1.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.9 (13.01.2023)
+* Update all dependencies.
+* Block egress traffic in GitHub Actions.
+* Add stability badge in README.
+
 ## 1.0.8 (28.12.2022)
 * Add Renovate as dependency update tool.
 * Keep read-only permissions in CI workflow.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "editorjs-break-line",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "keywords": [
     "tool",
     "divider",


### PR DESCRIPTION
## 1.0.9 (13.01.2023)
* Update all dependencies.
* Block egress traffic in GitHub Actions.
* Add stability badge in README.